### PR TITLE
bitbake: pyshyacc: allow double COMMA statements

### DIFF
--- a/bitbake/lib/bb/pysh/pyshyacc.py
+++ b/bitbake/lib/bb/pysh/pyshyacc.py
@@ -570,6 +570,7 @@ def p_linebreak(p):
 
 def p_separator_op(p):                 
     """separator_op : COMMA
+                    | COMMA COMMA
                     | AMP"""
     p[0] = p[1]
 


### PR DESCRIPTION
this allows shell statements like '; ;' to pass the parser.
As it may be bad code but still valid enough to execute

(Bitbake rev: b7732b1b5085bea73e17d112e1bd9ac3d4dc34fb)

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>